### PR TITLE
Unify the example document API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,11 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
-        "styled-components": "^6.1.1"
+        "slate": "^0.101.1",
+        "slate-react": "^0.101.1",
+        "styled-components": "^6.1.1",
+        "util-deprecate": "^1.0.2",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@babel/preset-react": "^7.23.3",
@@ -1405,6 +1409,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
+    },
     "node_modules/@mui/base": {
       "version": "5.0.0-beta.24",
       "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.24.tgz",
@@ -2054,6 +2063,16 @@
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "dev": true
+    },
+    "node_modules/@types/is-hotkey": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@types/is-hotkey/-/is-hotkey-0.1.10.tgz",
+      "integrity": "sha512-RvC8KMw5BCac1NvRRyaHgMMEtBaZ6wh0pyPTBu7izn4Sj/AX9Y4aXU5c7rX8PnM/knsuUpC1IeoBkANtxBypsQ=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
     },
     "node_modules/@types/node": {
       "version": "20.8.10",
@@ -2860,6 +2879,18 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
+    },
+    "node_modules/direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "bin": {
+        "direction": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -3673,6 +3704,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -3885,6 +3925,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hotkey": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.2.0.tgz",
+      "integrity": "sha512-UknnZK4RakDmTgz4PI1wIph5yxSs/mvChWs9ifnlXsKuXgWmOkY/hAE0H/k2MIqH0RlRye0i1oC07MCRSD28Mw=="
+    },
     "node_modules/is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
@@ -3936,6 +3981,14 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-regex": {
@@ -4220,6 +4273,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5757,6 +5815,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/slate": {
+      "version": "0.101.1",
+      "resolved": "https://registry.npmjs.org/slate/-/slate-0.101.1.tgz",
+      "integrity": "sha512-k/rVkVb0TEMmaTbkRVJeJzE8lxnyGDc0VC67D91Zrf5hcdHfVaWypBGD25QHCJsndn9Xa0jSJ/xfM2new5E2Zg==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "is-plain-object": "^5.0.0",
+        "tiny-warning": "^1.0.3"
+      }
+    },
+    "node_modules/slate-react": {
+      "version": "0.101.1",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.101.1.tgz",
+      "integrity": "sha512-YMUeqK4gWBguiQXczBWL2H4Y07R8Ux4ZzH22933a/IFr/+1Ue1d1AIcjl6JyF//OqaQN+rGvVfEhqZncDUTwOw==",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.4.0",
+        "@types/is-hotkey": "^0.1.8",
+        "@types/lodash": "^4.14.200",
+        "direction": "^1.0.4",
+        "is-hotkey": "^0.2.0",
+        "is-plain-object": "^5.0.0",
+        "lodash": "^4.17.21",
+        "scroll-into-view-if-needed": "^3.1.0",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "slate": ">=0.99.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -6057,6 +6146,16 @@
         "node": ">=12.22"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -6241,8 +6340,19 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
-    "styled-components": "^6.1.1"
+    "styled-components": "^6.1.1",
+    "slate": "^0.101.1",
+    "slate-react": "^0.101.1",
+    "util-deprecate": "^1.0.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.23.3",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import './App.css';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Home from '@/pages/Home';
 import Document from '@/pages/Document';
+import { DOC_ID_PARAM } from '@/util/constants';
 
 function App() {
   return (
@@ -9,7 +10,7 @@ function App() {
       <Router>
         <Routes>
           <Route path='/' exact element={<Home />} />
-          <Route path='/document' element={<Document />} />
+          <Route path={`/document/:${DOC_ID_PARAM}`} element={<Document />} />
         </Routes>
       </Router>
     </div >

--- a/src/assets/example_document.js
+++ b/src/assets/example_document.js
@@ -1,5 +1,50 @@
-const text = {
-    body: "Lorem ipsum dolor sit amet consectetur adipiscing elit. Donec tincidunt a sapien ornare mollis. Ut mattis eros nisi, sed posuere tortor cursus eget. Curabitur aliquet est libero, eget dapibus quam lobortis in. Etiam porta, sem nec hendrerit aliquam, dolor tellus pellentesque lorem, vel tincidunt nunc dui sit amet quam. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean lobortis auctor sem in pellentesque. Nulla gravida maximus vehicula. Phasellus et quam ut odio egestas scelerisque. Fusce in neque ac metus convallis vulputate. Nulla porttitor, odio sed efficitur egestas, velit est blandit lectus, sit amet condimentum tortor nisl at risus. Vestibulum lacinia euismod diam, sit amet pretium elit tempor a.\n\n Morbi eu libero felis. Quisque id fermentum dui. Integer viverra aliquet turpis, sed pellentesque mauris porttitor vel. Donec sodales dictum viverra. Etiam molestie, mi eu sodales porta, turpis augue mollis lorem, vitae pulvinar tellus turpis a neque. Curabitur pulvinar lorem ut turpis elementum facilisis. Pellentesque ut libero eu ante cursus placerat vitae eget magna. Nulla at viverra eros. Integer eget sapien ex. Morbi sit amet porttitor quam. Suspendisse potenti. Donec consequat, mi non ultrices dignissim, nisi lacus tempor tellus, nec varius erat est ut lacus. Aenean mattis tortor ut nisl ultricies cursus. Mauris vestibulum, dolor non viverra tempus, est risus rhoncus nulla, et ornare lectus odio faucibus ex. Curabitur posuere vulputate lectus, eget efficitur massa luctus nec.\n\nAliquam blandit ipsum eros, at iaculis metus eleifend id. Praesent ut sollicitudin nisl. Duis at justo tortor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aliquam feugiat vel nisi non posuere. Nulla accumsan quis neque eu aliquam. Phasellus id ante lectus. Maecenas eu turpis suscipit, luctus massa at, hendrerit massa. Suspendisse maximus augue diam, ac tincidunt odio efficitur vel. Vestibulum ultrices felis leo, tincidunt egestas neque ultricies in. In arcu magna, blandit consectetur mi a, viverra aliquet arcu. Integer quis tortor pretium, varius ante condimentum, aliquam neque. Mauris facilisis nulla et facilisis rutrum.\n\nMauris mi lacus, dictum eget tincidunt ac, tincidunt vel sapien. Nam quis sem placerat, tempus diam nec, vestibulum sem. Maecenas eu augue eleifend, fringilla quam nec, lobortis quam. Vestibulum id egestas elit. Sed vel ex ut mauris pretium fermentum vitae eget lorem. Phasellus eget metus tellus. Suspendisse sagittis dignissim nisl sit amet mollis.\n\nFusce a nisl dui. Praesent molestie, justo at dignissim blandit, velit ex volutpat metus, ut blandit velit ex eget ligula. Mauris suscipit leo magna, vel condimentum neque tempor aliquet. Ut et nisl interdum, vestibulum augue at, cursus nulla. Integer ornare ullamcorper metus, in laoreet velit rutrum nec. Morbi nec odio velit. Praesent eget sem magna. Nullam nisl tellus, porttitor in ex sed, mollis pretium dolor."
-}
+import { getMarkForCommentThreadID } from "@/util/editorCommentUtils";
+import { v4 as uuid } from "uuid";
 
-export default text
+const overlappingCommentThreadID = uuid();
+
+const ExampleDocument = [
+    {
+        type: "paragraph",
+        children: [
+            {
+                text: "Text 1",
+                [getMarkForCommentThreadID(uuid())]: true,
+            },
+            {
+                text: "Text 2",
+                [getMarkForCommentThreadID(overlappingCommentThreadID)]: true,
+            },
+            {
+                text: "Text 3",
+                [getMarkForCommentThreadID(overlappingCommentThreadID)]: true,
+                [getMarkForCommentThreadID(uuid())]: true,
+            },
+            {
+                text: "Text 4",
+                [getMarkForCommentThreadID(uuid())]: true,
+            },
+            {
+                text:
+                    " in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            },
+            { text: " massa." },
+        ],
+    },
+    {
+        type: "paragraph",
+        children: [
+            {
+                [getMarkForCommentThreadID(uuid())]: true,
+                text:
+                    "Cras maximus auctor congue. Sed ultrices elit quis tortor ornare, non gravida turpis feugiat. Morbi facilisis sodales sem quis feugiat. Vestibulum non urna lobortis, semper metus in, condimentum ex. Quisque est justo, egestas sit amet sem ac, auctor ultricies lacus. Pellentesque lorem justo, rhoncus ut magna sit amet, rhoncus posuere libero.",
+            },
+            {
+                text:
+                    "Cras maximus auctor congue. Sed ultrices elit quis tortor ornare, non gravida turpis feugiat. Morbi facilisis sodales sem quis feugiat. Vestibulum non urna lobortis, semper metus in, condimentum ex. Quisque est justo, egestas sit amet sem ac, auctor ultricies lacus. Pellentesque lorem justo, rhoncus ut magna sit amet, rhoncus posuere libero.",
+            },
+        ],
+    },
+];
+
+export default ExampleDocument;

--- a/src/assets/example_document.js
+++ b/src/assets/example_document.js
@@ -3,48 +3,50 @@ import { v4 as uuid } from "uuid";
 
 const overlappingCommentThreadID = uuid();
 
-const ExampleDocument = [
-    {
-        type: "paragraph",
-        children: [
-            {
-                text: "Text 1",
-                [getMarkForCommentThreadID(uuid())]: true,
-            },
-            {
-                text: "Text 2",
-                [getMarkForCommentThreadID(overlappingCommentThreadID)]: true,
-            },
-            {
-                text: "Text 3",
-                [getMarkForCommentThreadID(overlappingCommentThreadID)]: true,
-                [getMarkForCommentThreadID(uuid())]: true,
-            },
-            {
-                text: "Text 4",
-                [getMarkForCommentThreadID(uuid())]: true,
-            },
-            {
-                text:
-                    " in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-            },
-            { text: " massa." },
-        ],
-    },
-    {
-        type: "paragraph",
-        children: [
-            {
-                [getMarkForCommentThreadID(uuid())]: true,
-                text:
-                    "Cras maximus auctor congue. Sed ultrices elit quis tortor ornare, non gravida turpis feugiat. Morbi facilisis sodales sem quis feugiat. Vestibulum non urna lobortis, semper metus in, condimentum ex. Quisque est justo, egestas sit amet sem ac, auctor ultricies lacus. Pellentesque lorem justo, rhoncus ut magna sit amet, rhoncus posuere libero.",
-            },
-            {
-                text:
-                    "Cras maximus auctor congue. Sed ultrices elit quis tortor ornare, non gravida turpis feugiat. Morbi facilisis sodales sem quis feugiat. Vestibulum non urna lobortis, semper metus in, condimentum ex. Quisque est justo, egestas sit amet sem ac, auctor ultricies lacus. Pellentesque lorem justo, rhoncus ut magna sit amet, rhoncus posuere libero.",
-            },
-        ],
-    },
-];
+const ExampleDocument = {
+    children: [
+        {
+            type: "paragraph",
+            children: [
+                {
+                    text: "Text 1",
+                    [getMarkForCommentThreadID(uuid())]: true,
+                },
+                {
+                    text: "Text 2",
+                    [getMarkForCommentThreadID(overlappingCommentThreadID)]: true,
+                },
+                {
+                    text: "Text 3",
+                    [getMarkForCommentThreadID(overlappingCommentThreadID)]: true,
+                    [getMarkForCommentThreadID(uuid())]: true,
+                },
+                {
+                    text: "Text 4",
+                    [getMarkForCommentThreadID(uuid())]: true,
+                },
+                {
+                    text:
+                        " in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+                },
+                { text: " massa." },
+            ],
+        },
+        {
+            type: "paragraph",
+            children: [
+                {
+                    [getMarkForCommentThreadID(uuid())]: true,
+                    text:
+                        "Cras maximus auctor congue. Sed ultrices elit quis tortor ornare, non gravida turpis feugiat. Morbi facilisis sodales sem quis feugiat. Vestibulum non urna lobortis, semper metus in, condimentum ex. Quisque est justo, egestas sit amet sem ac, auctor ultricies lacus. Pellentesque lorem justo, rhoncus ut magna sit amet, rhoncus posuere libero.",
+                },
+                {
+                    text:
+                        "Cras maximus auctor congue. Sed ultrices elit quis tortor ornare, non gravida turpis feugiat. Morbi facilisis sodales sem quis feugiat. Vestibulum non urna lobortis, semper metus in, condimentum ex. Quisque est justo, egestas sit amet sem ac, auctor ultricies lacus. Pellentesque lorem justo, rhoncus ut magna sit amet, rhoncus posuere libero.",
+                },
+            ],
+        },
+    ]
+};
 
 export default ExampleDocument;

--- a/src/components/homepage/doc_selectors/GridSelector.jsx
+++ b/src/components/homepage/doc_selectors/GridSelector.jsx
@@ -1,9 +1,10 @@
 import Moment from 'moment';
 import { Link } from "react-router-dom";
 import DocFileIcon from "@/assets/home_doc_file_icon.svg";
+import { DOC_ID_QS } from '@/util/constants';
 
 const DocumentFile = ({ docInfo }) => {
-    return <Link to="/document">
+    return <Link to={`/document?${DOC_ID_QS}=${docInfo.id}`}>
         <div className="w-56 bg-gray-100 rounded-md flex flex-col">
             <div className="flex flex-col p-2 divide-y divide-black">
                 <img src={DocFileIcon} className="w-24 my-8 m-auto" />

--- a/src/components/homepage/doc_selectors/GridSelector.jsx
+++ b/src/components/homepage/doc_selectors/GridSelector.jsx
@@ -1,10 +1,9 @@
 import Moment from 'moment';
 import { Link } from "react-router-dom";
 import DocFileIcon from "@/assets/home_doc_file_icon.svg";
-import { DOC_ID_QS } from '@/util/constants';
 
 const DocumentFile = ({ docInfo }) => {
-    return <Link to={`/document?${DOC_ID_QS}=${docInfo.id}`}>
+    return <Link to={`/document/${docInfo.id}`}>
         <div className="w-56 bg-gray-100 rounded-md flex flex-col">
             <div className="flex flex-col p-2 divide-y divide-black">
                 <img src={DocFileIcon} className="w-24 my-8 m-auto" />

--- a/src/components/homepage/doc_selectors/ListSelector.jsx
+++ b/src/components/homepage/doc_selectors/ListSelector.jsx
@@ -5,7 +5,6 @@ import DocumentIcon from "@/assets/home_doc_file_icon.svg"
 import PfpIcon from "@/assets/pfp.svg"
 import TimeIcon from "@/assets/time.svg"
 import { useNavigate } from 'react-router-dom';
-import { DOC_ID_QS } from '../../../util/constants';
 
 const ListSelector = ({ docInfos }) => {
     const userIds = docInfos.map(di => di.owner)
@@ -51,7 +50,7 @@ const ListSelector = ({ docInfos }) => {
     }))
     const navigateToDoc = (record) => {
         return {
-            onClick: () => navigate({ pathname: "/document", search: `?${DOC_ID_QS}=${record.id}` })
+            onClick: () => navigate({ pathname: `/document/${record.id}` })
         }
     }
 

--- a/src/components/homepage/doc_selectors/ListSelector.jsx
+++ b/src/components/homepage/doc_selectors/ListSelector.jsx
@@ -5,6 +5,7 @@ import DocumentIcon from "@/assets/home_doc_file_icon.svg"
 import PfpIcon from "@/assets/pfp.svg"
 import TimeIcon from "@/assets/time.svg"
 import { useNavigate } from 'react-router-dom';
+import { DOC_ID_QS } from '../../../util/constants';
 
 const ListSelector = ({ docInfos }) => {
     const userIds = docInfos.map(di => di.owner)
@@ -50,7 +51,7 @@ const ListSelector = ({ docInfos }) => {
     }))
     const navigateToDoc = (record) => {
         return {
-            onClick: () => navigate({ pathname: "/document", search: `?id=${record.id}` })
+            onClick: () => navigate({ pathname: "/document", search: `?${DOC_ID_QS}=${record.id}` })
         }
     }
 

--- a/src/pages/Document.jsx
+++ b/src/pages/Document.jsx
@@ -1,14 +1,15 @@
 import '@/App.css'
 import { useState } from 'react'
 import Header from "@/components/document/Header/Header"
-import ViewToggleButton from '../components/document/Header/ViewToggleButton';
+import ViewToggleButton from '@/components/document/Header/ViewToggleButton';
 import DocumentSVG from "@/assets/document.svg"
 import TableSVG from "@/assets/table.svg"
 import CardSVG from "@/assets/pie_chart.svg"
-import DocumentView from '../components/document/DocumentView/DocumentView';
-import CardView from '../components/document/CardView/CardView';
-import TableView from '../components/document/TableView/TableView';
-import docText from "@/assets/example_document"
+import DocumentView from '@/components/document/DocumentView/DocumentView';
+import CardView from '@/components/document/CardView/CardView';
+import TableView from '@/components/document/TableView/TableView';
+import { useSearchParams } from 'react-router-dom';
+import docApi from "@/util/document_apis";
 
 function Document() {
   const [documentView, setDocumentView] = useState("document")
@@ -17,13 +18,18 @@ function Document() {
   const TableIcon = <img src={TableSVG} className="h-6" />
   const CardIcon = <img src={CardSVG} className="h-6" />
 
+  const [searchParams,] = useSearchParams();
+  const docId = searchParams.get("id") ?? 0
+
+  const fullDocument = docApi.getDocById(docId)
+
   const ViewComponent = () => {
     if (documentView == "document") {
-      return <DocumentView text={docText} />
+      return <DocumentView document={fullDocument} />
     } else if (documentView == "card") {
-      return <CardView text={docText} />
+      return <CardView document={fullDocument} />
     } else {
-      return <TableView text={docText} />
+      return <TableView document={fullDocument} />
     }
   }
 

--- a/src/pages/Document.jsx
+++ b/src/pages/Document.jsx
@@ -8,8 +8,9 @@ import CardSVG from "@/assets/pie_chart.svg"
 import DocumentView from '@/components/document/DocumentView/DocumentView';
 import CardView from '@/components/document/CardView/CardView';
 import TableView from '@/components/document/TableView/TableView';
-import { useSearchParams } from 'react-router-dom';
 import docApi from "@/util/document_apis";
+import { useParams } from 'react-router-dom';
+import { DOC_ID_PARAM } from '@/util/constants';
 
 function Document() {
   const [documentView, setDocumentView] = useState("document")
@@ -18,8 +19,7 @@ function Document() {
   const TableIcon = <img src={TableSVG} className="h-6" />
   const CardIcon = <img src={CardSVG} className="h-6" />
 
-  const [searchParams,] = useSearchParams();
-  const docId = searchParams.get("id") ?? 0
+  const docId = useParams()[DOC_ID_PARAM];
 
   const fullDocument = docApi.getDocById(docId)
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -13,7 +13,7 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import ListIcon from "@/assets/list.svg"
 import GridIcon from "@/assets/grid.svg"
-import ListSelector from "../components/homepage/doc_selectors/ListSelector";
+import ListSelector from "@/components/homepage/doc_selectors/ListSelector";
 
 const SORTING_OPTIONS = {
   name: "name",
@@ -109,7 +109,7 @@ const DocumentsSelectionTopBar = ({ resort, docLayout, setDocLayout }) => {
 }
 
 const Home = () => {
-  const docInfosRaw = DocApi.getAllDocIdsAndMetadata()
+  const docInfosRaw = DocApi.getAllDocsMetadata()
 
   // state management for customizing sort key
   const sorter = (currentDocInfos, newSortKey) => {

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -1,0 +1,1 @@
+export const DOC_ID_QS = "doc_id"

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -1,1 +1,1 @@
-export const DOC_ID_QS = "doc_id"
+export const DOC_ID_PARAM = "doc_id"

--- a/src/util/document_apis.js
+++ b/src/util/document_apis.js
@@ -10,7 +10,7 @@ const getAllDocs = () => {
 /*
     Gets ids, name, and dateLastModified (and other metadata) info about all docs
 */
-const getAllDocIdsAndMetadata = () => {
+const getAllDocsMetadata = () => {
     return AllDocs.map(doc => {
         var docMetadata = doc
         delete docMetadata['body']
@@ -20,9 +20,9 @@ const getAllDocIdsAndMetadata = () => {
 }
 
 /*
-    Get metadata of doc given its id
+    Get full document given its id
 */
-const getDocMetadataById = (id) => {
+const getDocById = (id) => {
     return AllDocs.find((e) => {
         return e.id == id;
     })
@@ -30,6 +30,6 @@ const getDocMetadataById = (id) => {
 
 export default {
     getAllDocs,
-    getAllDocIdsAndMetadata,
-    getDocMetadataById
+    getAllDocsMetadata,
+    getDocById
 }

--- a/src/util/editorCommentUtils.js
+++ b/src/util/editorCommentUtils.js
@@ -1,8 +1,15 @@
 import { v4 as uuid } from "uuid";
 import { Editor } from 'slate'
 
+// Almost all of this is pulled from the Slate documentation, and a tutorial on adding comments to Slate.
+// Reference links here: 
+// Slate docs: https://docs.slatejs.org/concepts/01-interfaces
+// Tutorial: https://www.smashingmagazine.com/2021/05/commenting-system-wysiwyg-editor/
+
 const COMMENT_THREAD_PREFIX = "commentThread_";
 
+// In this context, a mark is similar to a "bold" or "italic" tag that marks
+// a node as having the comment thread corresponding to threadID
 export function getMarkForCommentThreadID(threadID) {
     return `${COMMENT_THREAD_PREFIX}${threadID}`;
 }

--- a/src/util/editorCommentUtils.js
+++ b/src/util/editorCommentUtils.js
@@ -1,0 +1,42 @@
+import { v4 as uuid } from "uuid";
+import { Editor } from 'slate'
+
+const COMMENT_THREAD_PREFIX = "commentThread_";
+
+export function getMarkForCommentThreadID(threadID) {
+    return `${COMMENT_THREAD_PREFIX}${threadID}`;
+}
+
+export function getCommentThreadsOnTextNode(textnode) {
+    return new Set(
+        Object.keys(textnode)
+            .filter(isCommentThreadIDMark)
+            .map(getCommentThreadIDFromMark)
+    );
+}
+
+export function getCommentThreadIDFromMark(mark) {
+    if (!isCommentThreadIDMark(mark)) {
+        throw new Error("Expected mark to be of a comment thread");
+    }
+    return mark.replace(COMMENT_THREAD_PREFIX, "");
+}
+
+function isCommentThreadIDMark(mayBeCommentThread) {
+    return mayBeCommentThread.indexOf(COMMENT_THREAD_PREFIX) === 0;
+}
+
+export function insertCommentThread(editor, addCommentThreadToState) {
+    const threadID = uuid();
+    const newCommentThread = {
+        // comments as added would be appended to the thread here.
+        comments: [],
+        creationTime: new Date(),
+        // Newly created comment threads are OPEN. We deal with statuses
+        // later in the article.
+        status: "open",
+    };
+    addCommentThreadToState(threadID, newCommentThread);
+    Editor.addMark(editor, getMarkForCommentThreadID(threadID), true);
+    return threadID;
+}

--- a/src/util/test_documents.js
+++ b/src/util/test_documents.js
@@ -6,7 +6,7 @@ const randomDate = (start, end) => {
 }
 
 const AllDocs = () => {
-    const docs = [...Array(5).keys()].map((i) => {
+    const docs = [...Array(15).keys()].map((i) => {
         return {
             id: i,
             name: 'doc ' + i,

--- a/src/util/test_documents.js
+++ b/src/util/test_documents.js
@@ -1,41 +1,18 @@
-const texts = [
-    "Lorem ipsum dolor sit amet consectetur adipiscing elit. Donec tincidunt a sapien ornare mollis. Ut mattis eros nisi, sed posuere tortor cursus eget. Curabitur aliquet est libero, eget dapibus quam lobortis in. Etiam porta, sem nec hendrerit aliquam, dolor tellus pellentesque lorem, vel tincidunt nunc dui sit amet quam. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean lobortis auctor sem in pellentesque. Nulla gravida maximus vehicula. Phasellus et quam ut odio egestas scelerisque. Fusce in neque ac metus convallis vulputate. Nulla porttitor, odio sed efficitur egestas, velit est blandit lectus, sit amet condimentum tortor nisl at risus. Vestibulum lacinia euismod diam, sit amet pretium elit tempor a.\n\n Morbi eu libero felis. Quisque id fermentum dui. Integer viverra aliquet turpis, sed pellentesque mauris porttitor vel. Donec sodales dictum viverra. Etiam molestie, mi eu sodales porta, turpis augue mollis lorem, vitae pulvinar tellus turpis a neque. Curabitur pulvinar lorem ut turpis elementum facilisis. Pellentesque ut libero eu ante cursus placerat vitae eget magna. Nulla at viverra eros. Integer eget sapien ex. Morbi sit amet porttitor quam. Suspendisse potenti. Donec consequat, mi non ultrices dignissim, nisi lacus tempor tellus, nec varius erat est ut lacus. Aenean mattis tortor ut nisl ultricies cursus. Mauris vestibulum, dolor non viverra tempus, est risus rhoncus nulla, et ornare lectus odio faucibus ex. Curabitur posuere vulputate lectus, eget efficitur massa luctus nec.\n\nAliquam blandit ipsum eros, at iaculis metus eleifend id. Praesent ut sollicitudin nisl. Duis at justo tortor. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aliquam feugiat vel nisi non posuere. Nulla accumsan quis neque eu aliquam. Phasellus id ante lectus. Maecenas eu turpis suscipit, luctus massa at, hendrerit massa. Suspendisse maximus augue diam, ac tincidunt odio efficitur vel. Vestibulum ultrices felis leo, tincidunt egestas neque ultricies in. In arcu magna, blandit consectetur mi a, viverra aliquet arcu. Integer quis tortor pretium, varius ante condimentum, aliquam neque. Mauris facilisis nulla et facilisis rutrum.\n\nMauris mi lacus, dictum eget tincidunt ac, tincidunt vel sapien. Nam quis sem placerat, tempus diam nec, vestibulum sem. Maecenas eu augue eleifend, fringilla quam nec, lobortis quam. Vestibulum id egestas elit. Sed vel ex ut mauris pretium fermentum vitae eget lorem. Phasellus eget metus tellus. Suspendisse sagittis dignissim nisl sit amet mollis.\n\nFusce a nisl dui. Praesent molestie, justo at dignissim blandit, velit ex volutpat metus, ut blandit velit ex eget ligula. Mauris suscipit leo magna, vel condimentum neque tempor aliquet. Ut et nisl interdum, vestibulum augue at, cursus nulla. Integer ornare ullamcorper metus, in laoreet velit rutrum nec. Morbi nec odio velit. Praesent eget sem magna. Nullam nisl tellus, porttitor in ex sed, mollis pretium dolor.",
-    "Text Text Text Text Text Text Text",
-    "Him boisterous invitation dispatched had connection inhabiting projection. By mutual an mr danger garret edward an. Diverted as strictly exertion addition no disposal by stanhill. This call wife do so sigh no gate felt. You and abode spite order get. Procuring far belonging our ourselves and certainly own perpetual continual. It elsewhere of sometimes or my certainty. Lain no as five or at high. Everything travelling set how law literature.",
-    "Over fact all son tell this any his. No insisted confined of weddings to returned to debating rendered. Keeps order fully so do party means young. Table nay him jokes quick. In felicity up to graceful mistaken horrible consider. Abode never think to at. So additions necessary concluded it happiness do on certainly propriety",
-    "On recommend tolerably my belonging or am. Mutual has cannot beauty indeed now sussex merely you. It possible no husbands jennings ye offended packages pleasant he. Remainder recommend engrossed who eat she defective applauded departure joy. Get dissimilar not introduced day her apartments. Fully as taste he mr do smile abode every. Luckily offered article led lasting country minutes nor old. Happen people things oh is oppose up parish effect. Law handsome old outweigh humoured far appetite",
-    "cottage. Procuring as in resembled by in agreeable. Next long no gave mr eyes. Admiration advantages no he celebrated so pianoforte unreserved. Not its herself forming charmed amiable",
-    "Lose john poor same it case do year we. Full how way even the sigh. Extremely nor furniture fat questions now provision incommode preserved. Our side fail find like now. Discovered travelling for insensible partiality unpleasing impossible she. Sudden up my excuse to suffer ladies though or. Bachelor possible marianne directly confined relation as on he.",
-    "Alteration literature to or an sympathize mr imprudence. Of is ferrars subject as enjoyed or tedious cottage. Procuring as in resembled by in agreeable. Next long no gave mr eyes. Admiration advantages no he celebrated so pianoforte unreserved. Not its herself forming charmed amiable. Him why feebly expect future now.    ",
-    "g. Returned peculiar pleasant but appetite differed she. Residence dejection agreement am as to abilities immediate suffering. Ye am depending propriety sweetness distrusts belonging collected. Smiling mention he in thought equally musical. Wisdom new and valley answer. Contented it so is discourse recommend. Man its upon him call mile. An pasture",
-    "ondered disposal my speaking. Direct wholly valley or uneasy it at really. Sir wish like said dull and need make. Sportsman one bed departure rapturous situation disposing his. Off say yet ample ten ought hence. Depending in newspaper an september do existence strangers. Total great saw water had mirth happy new. Projecting pianoforte no of partiality is on. Na",
-    "r was settled for. Moreover end horrible endeavor entrance any families. Income appear extent on of thrown in admire. Stanhill on we if vicinity material in. Saw him smallest you provid",
-    " ask rapturous consulted. Object remark lively all did feebly excuse our wooded. Old her object chatty regard vulgar missed. Speaking throwing breeding betrayed children ",
-    "y off why half led have near bed. At engage simple father of period others except. My giving do summer of though narrow marked at. Spring formal no county ye waited. My whether cheered at regular it of promise blushes perhaps. Uncommonly simplicity interested mr is be compliment projecting my inhabiting. Gentleman he september in oh excelle",
-    " if of comparison pianoforte projection. Maids hoped gay yet bed asked blind dried point. On abroad danger likely regret twenty edward do. Too horrible consider followed may differed age. An rest if more five mr of. Age just her rank met down way. Attended required so in cheerful an. Domestic replying she resolved him for did. Rather in lasted no within n",
-    "Now seven world think timed while her. Spoil large oh he rooms on since an. Am up unwilling eagerness perceived incommode. Are not windows set luckily musical hundred can. Collecting if sympathize middletons be of of reasonably. Horrible so kindness at thoughts exercise no weddings subjects. The mrs gay removed towards journey chapter females offered not. Led distrusts otherwise who may newspaper but. Last he dull am none he mile hold as.",
-    "of though narrow marked at. Spring formal no county ye waited. My whether cheered at regular it of promise blushes perhaps. Uncommonly simplicity interested mr is be compli",
-]
+import ExampleDocument from "@/assets/example_document";
 
-//TODO: Temporary Document Body format
-const DocumentBody = (text) => {
-    return {
-        body: text
-    }
-}
 
 const randomDate = (start, end) => {
     return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
 }
 
 const AllDocs = () => {
-    const docs = texts.map((text, i) => {
+    const docs = [...Array(5).keys()].map((i) => {
         return {
             id: i,
             name: 'doc ' + i,
             dateLastModified: randomDate(new Date(2012, 0, 1), new Date()),
             owner: i,
-            body: DocumentBody(text)
+            body: ExampleDocument
         }
     })
 


### PR DESCRIPTION
Unifies all our example document systems, since we had like 3 separate ones before. I basically took Richard's example document API and replaced all the body texts with Emily's Slate format. So to recap, we have the 15 documents hooked into the home page, and each of them has the same Slate example text as its body.

When you click a document on the home page, it navigates you to the document page with the document id in its query string (this could use cleanup, I did it manually. Maybe we want it as a REST path instead of a query string param). The document page then pulls the id out of said query string, and uses it to get the document metadata + body. It passes this full document into each of its views (Table, Card, Document), and then the view does with it what it will. 

We'll each need to adapt our views to use this new structure, but it should be pretty straightforwards. Doing so probably depends on Emily's Slate integration PR to have a document editor component to use.