### PR TITLE
Added integration of Slate doc format to Table View

### DIFF
--- a/frontend/src/components/document/DocumentView/StyledText.jsx
+++ b/frontend/src/components/document/DocumentView/StyledText.jsx
@@ -1,6 +1,6 @@
 import { getCommentThreadsOnTextNode } from "@/util/editorCommentUtils";
 import { getRedactionsOnTextNode, getMarkFromLeaf } from "@/util/editorRedactionUtils";
-import CommentedText from "@/components/document/Document/CommentedText";
+import CommentedText from "@/components/document/DocumentView/CommentedText";
 import RedactedText from "@/components/document/Redactions/RedactedText";
 import RedactionPopover from "@/components/document/Redactions/RedactionPopover";
 


### PR DESCRIPTION
Updates Table View to work with the Slate doc format. The redaction suggestion is bracketed right now (ie: "lah blah [redacted words] blah") so I will figure out a solution for that
This doesn't support users making their own redactions, but it can be stretch goal, because this view wasn't intended for making redactions.
<img width="1353" alt="image" src="https://github.com/wendi-yu/newbloom/assets/46700318/e4662730-1b3b-4dbb-b3b8-23dd12fd3e5a">
