### PR TITLE
Add ML model API

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+backend/src/services/ml_model/** filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -20,11 +20,27 @@ Use nvm to install Node version 20.9.0:
 nvm install 20.9.0
 ```
 
-#### Insall Node modules
+#### git-lfs
+Our ML model files are quite large (>400MB), so we store them with [git-lfs](https://git-lfs.com/). Download (for Mac), and run all of these _after_ cloning the repo.
+```
+brew install git-lfs
+git lfs install
+git lfs fetch
+git lfs checkout
+```
+
+#### Install Node modules
 Run this command in the root folder, and in both the `backend` and `frontend` folders.
 
 ```zsh
 npm ci
+```
+
+#### Install Python modules too
+You can set up a venv if you'd like. Run this in the root folder.
+
+```zsh
+pip3 install -r requirements.txt
 ```
 
 ## App Dev Guidelines

--- a/backend/index.js
+++ b/backend/index.js
@@ -6,6 +6,9 @@ import { isAuthorized } from '#middleware/auth';
 // Create an instance of the express application
 const app = express();
 
+// parse request bodies as JSON
+app.use(express.json());
+
 // These routes won't be checked for auth
 app.use('/', loginRouter);
 // Attach auth guard - all attached routes after this will require auth

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,7 +7,21 @@
     "": {
       "name": "newbloom-backend",
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "child_process": "^1.0.2",
+        "express-async-handler": "^1.2.0"
+      }
+    },
+    "node_modules/child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g=="
+    },
+    "node_modules/express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,5 +18,9 @@
     "#configs/*": "./src/configs/*.js",
     "#services/*": "./src/services/*.js"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "child_process": "^1.0.2",
+    "express-async-handler": "^1.2.0"
+  }
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+spacy==3.5.1
+spacy-transformers==1.2.2

--- a/backend/src/controllers/fileController.js
+++ b/backend/src/controllers/fileController.js
@@ -1,0 +1,15 @@
+import asyncHandler from "express-async-handler"
+import runRedaction from "#services/modelService";
+
+// Handle file upload
+export const upload_file = asyncHandler(async (req, res, next) => {
+    // TODO: implement encryption/decryption of req.body["text"]
+    const redactions = await runRedaction(req.body["text"])
+        .catch(e => {
+            res.status(400).json({ message: "ML model error" })
+            next(e)
+        });
+    // TODO: implement other file upload actions (eg assign id, register it)
+    res.send({ "redactions": redactions })
+    next()
+});

--- a/backend/src/routes/router.js
+++ b/backend/src/routes/router.js
@@ -1,4 +1,13 @@
 import express from 'express';
+import { upload_file } from "#controllers/fileController"
 const router = express.Router()
+
+// health check route
+router.get('/', (req, res) => {
+    res.send('Ping success')
+})
+
+// redact test route
+router.post('/upload', upload_file)
 
 export { router }

--- a/backend/src/services/ml_model/apply_output.spacy
+++ b/backend/src/services/ml_model/apply_output.spacy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f1c2a8876741181c1d2043b5ee3954f1025a7dd6bd4ffc81dd06d5d91ca7836
+size 134820544

--- a/backend/src/services/ml_model/eval_metrics.json
+++ b/backend/src/services/ml_model/eval_metrics.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2a42563b761acf13ae78823a7cfc6da1dc4d8fa6bf27106d78160e456826376
+size 468

--- a/backend/src/services/ml_model/ml_model_runner.py
+++ b/backend/src/services/ml_model/ml_model_runner.py
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a431fb29248dd6bb825cbf213a2f2d2ca3d80dc09d2ffdec99a673b45baf1484
+size 942

--- a/backend/src/services/ml_model/model-best/config.cfg
+++ b/backend/src/services/ml_model/model-best/config.cfg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e66dca98a8a31b6b325dfd48272f4593811d548264e60b2340919406211efd87
+size 3385

--- a/backend/src/services/ml_model/model-best/meta.json
+++ b/backend/src/services/ml_model/model-best/meta.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7074bb4c1a415fd0543e23bd9167ead3eef75d730bc181f56a28e8d38db103d5
+size 737

--- a/backend/src/services/ml_model/model-best/spancat/cfg
+++ b/backend/src/services/ml_model/model-best/spancat/cfg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77856d4048177f993d4606eefe1f76b864fad13df23417630c6c9b4807b165b0
+size 172

--- a/backend/src/services/ml_model/model-best/spancat/model
+++ b/backend/src/services/ml_model/model-best/spancat/model
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98499a57476752b1c76e64b005262706a39ed79179c133c499ed076d97fa81f1
+size 4724523

--- a/backend/src/services/ml_model/model-best/tokenizer
+++ b/backend/src/services/ml_model/model-best/tokenizer
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b014e8bba4958b120af2d0c1c63eabb7c00379f2bacaf10df7c5325efd2ea467
+size 77066

--- a/backend/src/services/ml_model/model-best/transformer/cfg
+++ b/backend/src/services/ml_model/model-best/transformer/cfg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96757350a520bf2f2f63b4fdf49ac22e5609c4ccd5ae551632f66419fa395efe
+size 28

--- a/backend/src/services/ml_model/model-best/transformer/model
+++ b/backend/src/services/ml_model/model-best/transformer/model
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f712a4e40b0d6d7ec357b3ede01af57d40c067a6836eddf39c20489a3c81c038
+size 502030817

--- a/backend/src/services/ml_model/model-best/vocab/key2row
+++ b/backend/src/services/ml_model/model-best/vocab/key2row
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71
+size 1

--- a/backend/src/services/ml_model/model-best/vocab/lookups.bin
+++ b/backend/src/services/ml_model/model-best/vocab/lookups.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71
+size 1

--- a/backend/src/services/ml_model/model-best/vocab/strings.json
+++ b/backend/src/services/ml_model/model-best/vocab/strings.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06dc5ed52126853b0b1a612ef7eb934b0633d9e8cc41d07300ca4c8a2a2b05ba
+size 218200

--- a/backend/src/services/ml_model/model-best/vocab/vectors
+++ b/backend/src/services/ml_model/model-best/vocab/vectors
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14772b683e726436d5948ad3fff2b43d036ef2ebbe3458aafed6004e05a40706
+size 128

--- a/backend/src/services/ml_model/model-best/vocab/vectors.cfg
+++ b/backend/src/services/ml_model/model-best/vocab/vectors.cfg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff4359091952c8cd16f1f0482f5770fb82d1707368d5cca3c46aa501f552e3c5
+size 22

--- a/backend/src/services/modelService.js
+++ b/backend/src/services/modelService.js
@@ -1,0 +1,23 @@
+import spawn from "child_process"
+
+const runRedaction = async (fileBody) => {
+    return new Promise((resolve, reject) => {
+        const modelRunner = spawn.spawn('python3', ['src/services/ml_model/ml_model_runner.py', fileBody]);
+        let redactions = []
+        // save python script output (list of redactions) into outer redactions variable
+        modelRunner.stdout.on('data', (data) => {
+            redactions = JSON.parse(data.toString())
+        });
+        // handle errors
+        modelRunner.stderr.on('data', (data) => {
+            console.log(data.toString())
+            reject(Error(data.toString()))
+        })
+        // return once the stream closes
+        modelRunner.stdout.on('end', () => {
+            resolve(redactions)
+        })
+    })
+}
+
+export default runRedaction


### PR DESCRIPTION
Adds the API skeleton for uploading files (under `/upload`), and then adds the redaction-generating functionality to the API. Still need to complete the API by adding the file registering and so on. Here's an explanation of the changes I made, from the bottom up.

#### `services/ml_model/`
We got the ML model from Benn's repo [here](https://github.com/bennmcgregor/autoredact-demo). I put the model files in `services/ml_model`, and also included the Python script that runs the model in that folder. We're using Python to run it because the model needs to be run with SpaCy, which only really has a functioning interface in Python.

#### `services/modelService.js`
Since the rest of our backend is in JS, I used a JS module that basically spawns a thread that runs the Python script and communicates the arguments/returns through stdio. The JS code is in `modelService.js`, since this feels like a service and not a controller.

#### `controllers/fileController.js`
This is meant to be the controller that handles all file APIs. I've only added the `fileupload` one so far.

#### `routes/router.js`
This is where we're registering all of our roots.

## Testing
You can test by hitting `localhost:3000/upload` with a POST request, with a body of `{text: [an entire document to redact in string form]"`. it also has light error handling, if you give it bad input.

## Dev changes after this
We made some changes to the stack, so you'll need to run a few extra commands to get the backend to work. They're all listed in the README changes. Mostly just adding Python and git-lfs to hold all the giant model files.
