### PR TITLE
Make comments refreshable from db

### DIFF
--- a/backend/src/controllers/fileController.js
+++ b/backend/src/controllers/fileController.js
@@ -1,6 +1,7 @@
 import asyncHandler from "express-async-handler";
 import runRedaction from "#services/modelService";
 import { fileStringHash } from "#services/backendFileService";
+import db from "#database/db";
 
 // Handle file upload
 export const upload_file = asyncHandler(async (req, res, next) => {
@@ -12,6 +13,45 @@ export const upload_file = asyncHandler(async (req, res, next) => {
   });
   // TODO: implement other file upload actions (eg assign id, register it)
   const fileId = await fileStringHash(text);
+  await db.upsertFile(fileId, redactions).catch((e) => {
+    res.status(400).json({ message: "File registration failed" });
+    next(e);
+  });
   res.send({ redactions: redactions, id: fileId });
+  next();
+});
+
+export const updateFile = asyncHandler(async (req, res, next) => {
+  const fileId = req.body["fileId"];
+  const { accepts, rejects, suggestions, comments, comment_indices } =
+    req.body["state"];
+
+  await db
+    .upsertFile(
+      fileId,
+      suggestions,
+      accepts,
+      rejects,
+      comments,
+      comment_indices
+    )
+    .catch((e) => {
+      res.status(400).json({ message: "File registration failed" });
+      next(e);
+    });
+  res.send({ success: true });
+  next();
+});
+
+export const getFile = asyncHandler(async (req, res, next) => {
+  const fileId = req.query.fileId;
+  const file = await db.getFile(fileId).catch((e) => {
+    res.status(400).json({ message: "Failed to get file" });
+    next(e);
+  });
+
+  res.send({
+    file: file,
+  });
   next();
 });

--- a/backend/src/database/db.js
+++ b/backend/src/database/db.js
@@ -9,6 +9,38 @@ const pool = new Pool({
   },
 });
 
-export const getUsers = () => {
+const getUsers = () => {
   return pool.query("SELECT * FROM users;");
+};
+
+const upsertFile = async (
+  fileId,
+  suggestions,
+  accepts = [],
+  rejects = [],
+  comments = [],
+  comment_indices = []
+) => {
+  const res = await pool.query(
+    `INSERT INTO files (file_id, suggestions, accepts, rejects, comments, comment_indices) VALUES ('${fileId}', '${JSON.stringify(
+      suggestions
+    )}', '${JSON.stringify(accepts)}', '${JSON.stringify(
+      rejects
+    )}', '${JSON.stringify(comments)}', '${JSON.stringify(
+      comment_indices
+    )}') ON CONFLICT (file_id) DO UPDATE SET suggestions = EXCLUDED.suggestions, accepts = EXCLUDED.accepts, rejects = EXCLUDED.rejects, comments = EXCLUDED.comments, comment_indices = EXCLUDED.comment_indices;`
+  );
+
+  return res;
+};
+
+const getFile = async (fileId) => {
+  const res = await pool.query(`SELECT * FROM files WHERE file_id='${fileId}'`);
+  return res.rows[0];
+};
+
+export default {
+  getFile,
+  getUsers,
+  upsertFile,
 };

--- a/backend/src/database/files.sql
+++ b/backend/src/database/files.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS files (
     accepts JSON,
     rejects JSON,
     comments JSON,
+    comment_indices JSON,
     created_at TIMESTAMP DEFAULT current_timestamp,
     modified_at TIMESTAMP DEFAULT current_timestamp
 );

--- a/backend/src/routes/router.js
+++ b/backend/src/routes/router.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { upload_file } from "#controllers/fileController";
+import { upload_file, updateFile, getFile } from "#controllers/fileController";
 import { getUsers } from "#controllers/userController";
 const router = express.Router();
 
@@ -9,7 +9,9 @@ router.get("/", (req, res) => {
 });
 
 // redact test route
-router.post("/upload", upload_file);
+router.post("/file/upload", upload_file);
+router.post("/file/update", updateFile);
+router.get("/file/", getFile);
 
 router.get("/users", getUsers);
 

--- a/frontend/src/assets/refresh.svg
+++ b/frontend/src/assets/refresh.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 15L10 19L14 23" stroke="#494949" stroke-width="2"/>
+<path d="M18.0622 8.5C18.6766 9.56413 19 10.7712 19 12C19 13.2288 18.6766 14.4359 18.0622 15.5C17.4478 16.5641 16.5641 17.4478 15.5 18.0622C14.4359 18.6766 13.2288 19 12 19" stroke="#494949" stroke-width="2" stroke-linecap="round"/>
+<path d="M10 9L14 5L10 1" stroke="#494949" stroke-width="2"/>
+<path d="M5.93782 15.5C5.32344 14.4359 5 13.2288 5 12C5 10.7712 5.32344 9.56413 5.93782 8.5C6.5522 7.43587 7.43587 6.5522 8.5 5.93782C9.56413 5.32344 10.7712 5 12 5" stroke="#494949" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/refresh_purple.svg
+++ b/frontend/src/assets/refresh_purple.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14 15L10 19L14 23" stroke="#5C00B8" stroke-width="2"/>
+<path d="M18.0622 8.5C18.6766 9.56413 19 10.7712 19 12C19 13.2288 18.6766 14.4359 18.0622 15.5C17.4478 16.5641 16.5641 17.4478 15.5 18.0622C14.4359 18.6766 13.2288 19 12 19" stroke="#5C00B8" stroke-width="2" stroke-linecap="round"/>
+<path d="M10 9L14 5L10 1" stroke="#5C00B8" stroke-width="2"/>
+<path d="M5.93782 15.5C5.32344 14.4359 5 13.2288 5 12C5 10.7712 5.32344 9.56413 5.93782 8.5C6.5522 7.43587 7.43587 6.5522 8.5 5.93782C9.56413 5.32344 10.7712 5 12 5" stroke="#5C00B8" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/components/TextEditor.jsx
+++ b/frontend/src/components/TextEditor.jsx
@@ -87,6 +87,7 @@ export default function TextEditor({
                 />
               </div>
             </div>
+            <CommentSideBar refresh={commentRefresh} />
           </div>
         </div>
       </Slate>

--- a/frontend/src/components/common/ToolBar/Toolbar.jsx
+++ b/frontend/src/components/common/ToolBar/Toolbar.jsx
@@ -2,6 +2,7 @@ import CommentSVG from "@/assets/comment_fill_gray.svg";
 import RedactSVG from "@/assets/edit_fill.svg";
 import PrintSVG from "@/assets/print_fill.svg";
 import MarkAsDoneSVG from "@/assets/book_check_fill.svg";
+import RefreshSVG from "@/assets/refresh.svg";
 
 import UndoSVG from "@/assets/undo.svg";
 import RedoSVG from "@/assets/redo.svg";
@@ -13,19 +14,20 @@ import PurpleCommentSVG from "@/assets/comment_fill_purple.svg";
 import PurpleRedactSVG from "@/assets/edit_fill_purple.svg";
 import PurplePrintSVG from "@/assets/print_fill_purple.svg";
 import PurpleMarkAsDoneSVG from "@/assets/book_check_fill_purple.svg";
+import PurpleRefreshSVG from "@/assets/refresh_purple.svg";
 
 import { useSlate } from "slate-react";
 import { useCallback } from "react";
 import { useSetRecoilState } from "recoil";
 
 import HoverableIcon from "@/components/common/HoverableIcon";
-import { exportDoc, markAsDone } from "@/util/toolbar_functions.js";
+import { exportDoc, markAsDone, refresh } from "@/util/toolbar_functions.js";
 import { getTextFromSelection } from "@/util/editor_utils";
 import { insertMaybeComment } from "@/util/editorCommentUtils";
 import { insertRedaction, ACCEPTED_PREFIX } from "@/util/editorRedactionUtils";
 import { maybeCommentAtom } from "@/util/CommentRedactionState";
 
-export default function Toolbar({document}) {
+export default function Toolbar({ document, onRefresh }) {
   const editor = useSlate();
 
   const setMaybeComment = useSetRecoilState(maybeCommentAtom);
@@ -77,7 +79,13 @@ export default function Toolbar({document}) {
         <HoverableIcon
           SVG={MarkAsDoneSVG}
           SVGonHover={PurpleMarkAsDoneSVG}
-          onClick={markAsDone}
+          onClick={() => markAsDone(document)}
+          height={7}
+        />
+        <HoverableIcon
+          SVG={RefreshSVG}
+          SVGonHover={PurpleRefreshSVG}
+          onClick={() => refresh(document, onRefresh)}
           height={7}
         />
       </div>

--- a/frontend/src/components/common/ToolBar/Toolbar.jsx
+++ b/frontend/src/components/common/ToolBar/Toolbar.jsx
@@ -16,6 +16,8 @@ import PurplePrintSVG from "@/assets/print_fill_purple.svg";
 import PurpleMarkAsDoneSVG from "@/assets/book_check_fill_purple.svg";
 import PurpleRefreshSVG from "@/assets/refresh_purple.svg";
 
+import CheckSVG from "@/assets/check_fill.svg";
+
 import { useSlate } from "slate-react";
 import { useCallback } from "react";
 import { useSetRecoilState } from "recoil";
@@ -26,6 +28,7 @@ import { getTextFromSelection } from "@/util/editor_utils";
 import { insertMaybeComment } from "@/util/editorCommentUtils";
 import { insertRedaction, ACCEPTED_PREFIX } from "@/util/editorRedactionUtils";
 import { maybeCommentAtom } from "@/util/CommentRedactionState";
+import { notification } from "antd";
 
 export default function Toolbar({ document, onRefresh }) {
   const editor = useSlate();
@@ -40,6 +43,16 @@ export default function Toolbar({ document, onRefresh }) {
   const redact = useCallback(() => {
     insertRedaction(editor, ACCEPTED_PREFIX);
   }, [editor]);
+
+  const [api, contextHolder] = notification.useNotification();
+
+  const openNotificationWithIcon = () => {
+    api.open({
+      message: "Synced successfully",
+      placement: "bottomRight",
+      icon: <img src={CheckSVG} />,
+    });
+  };
 
   return (
     <div className="flex flex-row bg-gray-200 w-full space-x-6 pl-4 py-2 items-center">
@@ -79,15 +92,22 @@ export default function Toolbar({ document, onRefresh }) {
         <HoverableIcon
           SVG={MarkAsDoneSVG}
           SVGonHover={PurpleMarkAsDoneSVG}
-          onClick={() => markAsDone(document)}
+          onClick={() => {
+            markAsDone(document);
+            openNotificationWithIcon();
+          }}
           height={7}
         />
         <HoverableIcon
           SVG={RefreshSVG}
           SVGonHover={PurpleRefreshSVG}
-          onClick={() => refresh(document, onRefresh)}
+          onClick={() => {
+            refresh(document, onRefresh);
+            openNotificationWithIcon();
+          }}
           height={7}
         />
+        {contextHolder}
       </div>
     </div>
   );

--- a/frontend/src/components/document/CardView/CardView.jsx
+++ b/frontend/src/components/document/CardView/CardView.jsx
@@ -107,7 +107,7 @@ const CardView = ({ document }) => {
         initialValue={[{ children: cards[selectedIdx].body }]}
         onChange={onChange}
       >
-        <Toolbar document={document}/>
+        <Toolbar document={document} />
         <div className="w-80 float-left h-full pb-8">
           <CardSelector
             cards={cards}

--- a/frontend/src/components/document/Comments/CommentSideBar.jsx
+++ b/frontend/src/components/document/Comments/CommentSideBar.jsx
@@ -17,6 +17,7 @@ function CommentSideBar({ refresh }) {
       setComments(allComments);
     }
   }, [docId, refresh]);
+  console.log(comments);
 
   return (
     <div className="flex flex-col mt-20 mb-7 space-y-4 w-72">

--- a/frontend/src/util/api/document_apis.js
+++ b/frontend/src/util/api/document_apis.js
@@ -34,7 +34,7 @@ const getDocById = (id) => {
 };
 
 const postDoc = async (docText) => {
-  const url = `http://${API_DOMAIN}/upload`;
+  const url = `http://${API_DOMAIN}/file/upload`;
   const config = {
     headers: {
       // Overwrite Axios's automatically set Content-Type
@@ -53,7 +53,52 @@ const postDoc = async (docText) => {
   return data;
 };
 
+const updateDoc = async (fileId, state) => {
+  const url = `http://${API_DOMAIN}/file/update`;
+  const config = {
+    headers: {
+      // Overwrite Axios's automatically set Content-Type
+      "Content-Type": "application/json",
+    },
+  };
+
+  let data;
+  try {
+    const resp = await axios.post(
+      url,
+      { fileId: fileId, state: state },
+      config
+    );
+    data = resp.data;
+  } catch (error) {
+    console.log("Error uploading files: ", error);
+  }
+
+  return data;
+};
+
+const getDoc = async (fileId) => {
+  const url = `http://${API_DOMAIN}/file`;
+  const config = {
+    params: {
+      fileId: fileId,
+    },
+  };
+
+  let data;
+  try {
+    const resp = await axios.get(url, config);
+    data = resp.data;
+  } catch (error) {
+    console.log("Error uploading files: ", error);
+  }
+
+  return data;
+};
+
 export default {
+  getDoc,
+  updateDoc,
   postDoc,
   getAllDocs,
   getAllDocsMetadata,

--- a/frontend/src/util/editorCommentUtils.js
+++ b/frontend/src/util/editorCommentUtils.js
@@ -1,106 +1,116 @@
 import { v4 as uuid } from "uuid";
-import { Editor, Node } from 'slate';
+import { Editor, Node } from "slate";
 import { getUserById, getCurrentUser } from "@/util/api/user_apis";
 
 import docApi from "@/util/api/document_apis";
+import { getMarkFromLeaf } from "./editorRedactionUtils";
 
-const COMMENT_THREAD_PREFIX = "commentThread_";
+export const COMMENT_THREAD_PREFIX = "commentThread_";
 const MAYBE_COMMENT = "isMaybeComment";
 
 // In this context, a mark is similar to a "bold" or "italic" tag that marks
 // a node as having the comment thread corresponding to threadID
 export function getMarkForCommentThreadID(threadID) {
-    return `${COMMENT_THREAD_PREFIX}${threadID}`;
+  return `${COMMENT_THREAD_PREFIX}${threadID}`;
+}
+
+export function isComment(leaf) {
+  const mark = getMarkFromLeaf(leaf);
+  return mark && isCommentThreadIDMark(mark);
 }
 
 export function getCommentThreadsOnTextNode(textnode) {
-    return new Set(
-        Object.keys(textnode)
-            .filter(isCommentThreadIDMark)
-            .map(getCommentThreadIDFromMark)
-    );
+  return new Set(
+    Object.keys(textnode)
+      .filter(isCommentThreadIDMark)
+      .map(getCommentThreadIDFromMark)
+  );
 }
 
 export function ifCommentThreadsEqual(node1, node2) {
-    // TODO: find a better way to check for equality
-    if (!node1 || !node2) return false;
-    if (node1.size !== node2.size) return false;
-    return node1.text == node2.text ? true : false;
+  // TODO: find a better way to check for equality
+  if (!node1 || !node2) return false;
+  if (node1.size !== node2.size) return false;
+  return node1.text == node2.text ? true : false;
 }
 
 export function getAllChildCommentThreads(element) {
-    const threadIds = {}
-    for (const t of Node.texts(element)) {
-        // a ratchet set, since the actual one doesn't work very well
-        getCommentThreadsOnTextNode(t[0]).forEach(newId => threadIds[newId] = true)
-    }
-    return threadIds
+  const threadIds = {};
+  for (const t of Node.texts(element)) {
+    // a ratchet set, since the actual one doesn't work very well
+    getCommentThreadsOnTextNode(t[0]).forEach(
+      (newId) => (threadIds[newId] = true)
+    );
+  }
+  return threadIds;
 }
 
 export function getCommentThreadIDFromMark(mark) {
-    if (!isCommentThreadIDMark(mark)) {
-        throw new Error("Expected mark to be of a comment thread");
-    }
-    return mark.replace(COMMENT_THREAD_PREFIX, "");
+  if (!isCommentThreadIDMark(mark)) {
+    throw new Error("Expected mark to be of a comment thread");
+  }
+  return mark.replace(COMMENT_THREAD_PREFIX, "");
 }
 
 function isCommentThreadIDMark(mayBeCommentThread) {
-    return mayBeCommentThread.indexOf(COMMENT_THREAD_PREFIX) === 0;
+  return mayBeCommentThread.indexOf(COMMENT_THREAD_PREFIX) === 0;
 }
 
-export function insertMaybeComment (editor, selectedText, setMaybeComment) {
-    setMaybeComment(selectedText);
-    Editor.addMark(editor, MAYBE_COMMENT, true);
+export function insertMaybeComment(editor, selectedText, setMaybeComment) {
+  setMaybeComment(selectedText);
+  Editor.addMark(editor, MAYBE_COMMENT, true);
 }
 
 export function ifMaybeCommentOnTextNode(textnode) {
-    const keys = Object.keys(textnode)
+  const keys = Object.keys(textnode);
 
-    if(keys.some(key => key === MAYBE_COMMENT)) {
-        return true
-    }
-    
-    return false;
+  if (keys.some((key) => key === MAYBE_COMMENT)) {
+    return true;
+  }
+
+  return false;
 }
 
 //selection must be on mark to delete maybe comment
 //will hopefully change this in next pr (active comments)
 export function deleteMaybeComment(editor, setMaybeComment) {
-    Editor.removeMark(editor, MAYBE_COMMENT);
-    setMaybeComment(null);
+  Editor.removeMark(editor, MAYBE_COMMENT);
+  setMaybeComment(null);
 }
 
 export function insertCommentThread(editor, addCommentThreadToState) {
-    const threadID = uuid();
-    const user = getUserById(getCurrentUser());
-    const newCommentThread = {
-        // comments as added would be appended to the thread here.
-        comments: [],
-        creationTime: new Date(),
-        // Newly created comment threads are OPEN. We deal with statuses
-        // later in the article.
-        author: user.name,
-        status: "open",
-    };
-    addCommentThreadToState(threadID, newCommentThread);
-    Editor.addMark(editor, getMarkForCommentThreadID(threadID), true);
-    
-    return threadID;
+  const threadID = uuid();
+  const user = getUserById(getCurrentUser());
+  const newCommentThread = {
+    // comments as added would be appended to the thread here.
+    comments: [],
+    creationTime: new Date(),
+    // Newly created comment threads are OPEN. We deal with statuses
+    // later in the article.
+    author: user.name,
+    status: "open",
+  };
+  addCommentThreadToState(threadID, newCommentThread);
+  Editor.addMark(editor, getMarkForCommentThreadID(threadID), true);
+
+  return threadID;
 }
 
-export async function initializeStateWithAllCommentThreads(docId, addCommentThread ) {
-    const doc = docApi.getDocById(docId);
+export async function initializeStateWithAllCommentThreads(
+  docId,
+  addCommentThread
+) {
+  const doc = docApi.getDocById(docId);
 
-    if(!doc || !doc.comments) {
-        console.log("Document doesn't exist or has no comments.");
-        return;
-    }
+  if (!doc || !doc.comments) {
+    console.log("Document doesn't exist or has no comments.");
+    return;
+  }
 
-    doc.comments.forEach(comment => {
-        addCommentThread(comment.id, {
-            comments: [comment],
-            status: "open"
-        });
-    })
-    
+  doc.comments.forEach((comment) => {
+    addCommentThread(comment.id, {
+      comments: [comment],
+      status: "open",
+    });
+  });
 }

--- a/frontend/src/util/editorRedactionUtils.js
+++ b/frontend/src/util/editorRedactionUtils.js
@@ -2,6 +2,7 @@ import { v4 as uuid } from "uuid";
 import { Editor } from "slate";
 
 import { setSelectionToCurrNodeEdges } from "@/util/editor_utils";
+import { COMMENT_THREAD_PREFIX } from "./editorCommentUtils";
 
 export const SUGGESTION_PREFIX = "suggestion_";
 export const REJECTED_PREFIX = "rejected_";
@@ -31,7 +32,12 @@ export function isRedactionFromMark(mark) {
 
 export function getTargetFromMark(mark) {
   let res = null;
-  [ACCEPTED_PREFIX, SUGGESTION_PREFIX, REJECTED_PREFIX].forEach((pre) => {
+  [
+    ACCEPTED_PREFIX,
+    SUGGESTION_PREFIX,
+    REJECTED_PREFIX,
+    COMMENT_THREAD_PREFIX,
+  ].forEach((pre) => {
     if (mark.includes(pre)) {
       res = pre;
     }
@@ -40,8 +46,8 @@ export function getTargetFromMark(mark) {
 }
 
 export function getMarkFromLeaf(leaf) {
-  const key = Object.keys(leaf);
-  return key[1];
+  const keys = Object.keys(leaf);
+  return keys.filter((key) => key !== "text")[0];
 }
 
 export function replaceRedactionWithX(leaf) {
@@ -66,9 +72,13 @@ export function getMarkForRedactionID(threadID, target) {
   return `${target}${threadID}`;
 }
 
-export function insertRedaction(editor, target) {
+export function insertRedaction(editor, target, threadID) {
+  if (!threadID) {
+    threadID = uuid();
+  }
+
   //check if editor already has a redaction
-  const threadID = uuid();
+
   Editor.addMark(editor, getMarkForRedactionID(threadID, target), true);
   return threadID;
 }

--- a/frontend/src/util/localDocStore.js
+++ b/frontend/src/util/localDocStore.js
@@ -7,7 +7,12 @@ const addDocument = (name, id, state) => {
   let docHashesString = localStorage.getItem(userId);
   const docHashes = docHashesString ? JSON.parse(docHashesString) : {};
   // todo: warning if we''re going to overwrite
-  docHashes[id] = { name: name, state: state, dateAdded: new Date(), comments:[] };
+  docHashes[id] = {
+    name: name,
+    state: state,
+    dateAdded: new Date(),
+    comments: [],
+  };
 
   localStorage.setItem(userId, JSON.stringify(docHashes));
 };
@@ -47,6 +52,21 @@ export const addCommentToDocument = (docId, newComment) => {
   localStorage.setItem(userId, JSON.stringify(docHashes));
 };
 
+export const setDocumentComments = (docId, comments) => {
+  const userId = getCurrentUser();
+
+  let docHashesString = localStorage.getItem(userId);
+  if (!docHashesString) {
+    console.error(`document ${docId} not found`);
+    return;
+  }
+
+  const docHashes = JSON.parse(docHashesString);
+  docHashes[docId].comments = comments;
+
+  localStorage.setItem(userId, JSON.stringify(docHashes));
+};
+
 export const getAllCommentsFromDoc = (docId) => {
   const userId = getCurrentUser();
 
@@ -59,7 +79,7 @@ export const getAllCommentsFromDoc = (docId) => {
   const docHashes = JSON.parse(docHashesString);
   const document = docHashes[docId];
 
-  if (!document.comments) return null;
+  if (!document || !document.comments) return null;
   return document.comments;
 };
 

--- a/frontend/src/util/slateUtil.js
+++ b/frontend/src/util/slateUtil.js
@@ -1,6 +1,18 @@
-import { Node, Transforms } from "slate";
-import { createEditor } from "slate";
-import { SUGGESTION_PREFIX, insertRedaction } from "./editorRedactionUtils";
+import { Node, Transforms, createEditor } from "slate";
+import {
+  ACCEPTED_PREFIX,
+  REJECTED_PREFIX,
+  SUGGESTION_PREFIX,
+  getMarkFromLeaf,
+  getTargetFromMark,
+  insertRedaction,
+  isRedaction,
+} from "./editorRedactionUtils";
+import {
+  COMMENT_THREAD_PREFIX,
+  getCommentThreadIDFromMark,
+  isComment,
+} from "./editorCommentUtils";
 
 export const toText = (nodes) => {
   if (!Array.isArray(nodes)) {
@@ -11,38 +23,19 @@ export const toText = (nodes) => {
     for (const t of Node.texts(node)) {
       s += t[0].text;
     }
+    s += "\n\n";
   });
   return s;
 };
 
-export const toSlateFormat = (text, redactions) => {
-  // get the separated paragraph strings
-  const paragraphs = text.split("\n\n");
-
-  // get the indexes where the split happens
-  let counter = 0;
-  const paragraphSplits = paragraphs.map((par) => {
-    // add 2 to compensate for the 2 \n characters that are missing
-    counter += par.length + 2;
-    return counter;
-  });
-
-  // sort the redactions
-  const redactionsOrdered = redactions.sort((a, b) => a.start - b.start);
-
-  // final result to iterate through: pair paragraph strings with their lists of redactions
-  // redaction indices must be normalized to the paragraph
-  const paragraphsWithRedactions = paragraphs.map((par) => {
-    return {
-      text: par,
-      redactions: [],
-    };
-  });
-
-  // go through all the redactions, keep track of which paragraph's index range we're currently in
-  // to be able to sort the redaction into the right bucket
+const paragraphizeIndices = (
+  orderedIndices,
+  paragraphsWithRedactions,
+  paragraphSplits,
+  key
+) => {
   let currentParagraph = 0;
-  redactionsOrdered.forEach((redaction) => {
+  orderedIndices.forEach((redaction) => {
     // update paragraph counter
     while (redaction.start > paragraphSplits[currentParagraph]) {
       currentParagraph++;
@@ -55,7 +48,76 @@ export const toSlateFormat = (text, redactions) => {
     paragraphsWithRedactions[currentParagraph].redactions.push({
       start: redaction.start - locationOfLastSplit,
       end: redaction.end - locationOfLastSplit,
+      type: key,
+      id: redaction.id,
     });
+  });
+};
+
+export const toSlateFormat = (
+  text,
+  redactions,
+  accepts = [],
+  rejects = [],
+  comments = [],
+  originalCountsNewlines = true
+) => {
+  // get the separated paragraph strings
+  const paragraphs = text.split("\n\n");
+
+  // get the indexes where the split happens
+  let counter = 0;
+  const paragraphSplits = paragraphs.map((par) => {
+    // add 2 to compensate for the 2 \n characters that are missing
+    counter += par.length;
+    if (originalCountsNewlines) counter += 2;
+    return counter;
+  });
+
+  // sort the redactions
+  const redactionsOrdered = redactions.sort((a, b) => a.start - b.start);
+  const acceptsOrdered = accepts.sort((a, b) => a.start - b.start);
+  const rejectsOrdered = rejects.sort((a, b) => a.start - b.start);
+  const commentsOrdered = comments.sort((a, b) => a.start - b.start);
+
+  // final result to iterate through: pair paragraph strings with their lists of redactions
+  // redaction indices must be normalized to the paragraph
+  const paragraphsWithRedactions = paragraphs.map((par) => {
+    return {
+      text: par,
+      redactions: [],
+    };
+  });
+
+  // go through all the redactions, keep track of which paragraph's index range we're currently in
+  // to be able to sort the redaction into the right bucket
+  paragraphizeIndices(
+    redactionsOrdered,
+    paragraphsWithRedactions,
+    paragraphSplits,
+    SUGGESTION_PREFIX
+  );
+  paragraphizeIndices(
+    acceptsOrdered,
+    paragraphsWithRedactions,
+    paragraphSplits,
+    ACCEPTED_PREFIX
+  );
+  paragraphizeIndices(
+    rejectsOrdered,
+    paragraphsWithRedactions,
+    paragraphSplits,
+    REJECTED_PREFIX
+  );
+  paragraphizeIndices(
+    commentsOrdered,
+    paragraphsWithRedactions,
+    paragraphSplits,
+    COMMENT_THREAD_PREFIX
+  );
+
+  paragraphsWithRedactions.forEach((redText) => {
+    redText.redactions.sort((a, b) => a.start - b.start);
   });
 
   // apply the slate transformation to each paragraph individually
@@ -103,9 +165,43 @@ const paragraphToSlateFormat = (text, redactions) => {
         offset: red.distanceToLast + red.width,
       },
     });
-    insertRedaction(editor, SUGGESTION_PREFIX);
+
+    insertRedaction(editor, red.type, red.id);
   });
 
   // return the list of text nodes
   return editor.children[0].children;
+};
+
+export const slateToIndices = (children) => {
+  const results = {
+    [SUGGESTION_PREFIX]: [],
+    [ACCEPTED_PREFIX]: [],
+    [REJECTED_PREFIX]: [],
+    [COMMENT_THREAD_PREFIX]: [],
+  };
+
+  let currentIdx = 0;
+  children.forEach((child) => {
+    for (let [leaf] of Node.texts(child)) {
+      const endIdx = currentIdx + leaf.text.length;
+      if (isRedaction(leaf) || isComment(leaf)) {
+        const mark = getMarkFromLeaf(leaf);
+        const type = getTargetFromMark(mark);
+        const entry = { start: currentIdx, end: endIdx };
+        if (type === COMMENT_THREAD_PREFIX) {
+          entry.id = getCommentThreadIDFromMark(mark);
+        }
+        results[type].push(entry);
+      }
+      currentIdx = endIdx;
+    }
+  });
+
+  return {
+    suggestions: results[SUGGESTION_PREFIX],
+    accepts: results[ACCEPTED_PREFIX],
+    rejects: results[REJECTED_PREFIX],
+    comment_indices: results[COMMENT_THREAD_PREFIX],
+  };
 };

--- a/frontend/src/util/toolbar_functions.js
+++ b/frontend/src/util/toolbar_functions.js
@@ -1,42 +1,68 @@
-import jsPDF from 'jspdf';
-import { ACCEPTED_PREFIX, getRedactionsOnTextNode } from "@/util/editorRedactionUtils";
+import jsPDF from "jspdf";
+import {
+  ACCEPTED_PREFIX,
+  getRedactionsOnTextNode,
+} from "@/util/editorRedactionUtils";
+import { slateToIndices, toSlateFormat, toText } from "./slateUtil";
+import docApi from "./api/document_apis";
+import { getAllCommentsFromDoc, setDocumentComments } from "./localDocStore";
 
 export const toPDF = (body) => {
-    return Array.from(body.document.documentBody)
-        .map((paragraph) => {
-            const p_tag_start = "<p>";
-            const p_tag_end = "</p>";
-            const internal_text = paragraph.children.map((node) => {
-                const isAccepted = getRedactionsOnTextNode(node, ACCEPTED_PREFIX).size > 0;
-                return isAccepted ? "XXXXX" : node.text.replace("\n", p_tag_end + "<br>" + p_tag_start);
-            });
+  return Array.from(body.document.documentBody)
+    .map((paragraph) => {
+      const p_tag_start = "<p>";
+      const p_tag_end = "</p>";
+      const internal_text = paragraph.children.map((node) => {
+        const isAccepted =
+          getRedactionsOnTextNode(node, ACCEPTED_PREFIX).size > 0;
+        return isAccepted
+          ? "XXXXX"
+          : node.text.replace("\n", p_tag_end + "<br>" + p_tag_start);
+      });
 
-            const res = p_tag_start + internal_text.join(" ") + p_tag_end;
-            return res;
-        }
-    )
+      const res = p_tag_start + internal_text.join(" ") + p_tag_end;
+      return res;
+    })
     .join("<br>");
 };
 
 export function exportDoc(document) {
-    const pdf_doc = new jsPDF({
-        orientation: "portrait",
-        unit: "pt",
-        format: 'letter'
-    });
+  const pdf_doc = new jsPDF({
+    orientation: "portrait",
+    unit: "pt",
+    format: "letter",
+  });
 
-    let str = toPDF(document)
+  let str = toPDF(document);
 
-    pdf_doc.html(str, {
-        async callback(doc) {
-            await doc.save('pdf_name');
-        },
-        width: 560,
-        windowWidth: 560,
-        margin: [30, 30, 30, 30]
-    });
+  pdf_doc.html(str, {
+    async callback(doc) {
+      await doc.save("pdf_name");
+    },
+    width: 560,
+    windowWidth: 560,
+    margin: [30, 30, 30, 30],
+  });
 }
 
-export function markAsDone() {
+export async function markAsDone(document) {
+  const indexForm = slateToIndices(document.documentBody);
+  const allComments = getAllCommentsFromDoc(document.id);
+  await docApi.updateDoc(document.id, { ...indexForm, comments: allComments });
+}
 
+export async function refresh(document, onRefresh) {
+  const dbFile = (await docApi.getDoc(document.id)).file;
+  const slateForm = toSlateFormat(
+    toText(document.documentBody),
+    dbFile.suggestions,
+    dbFile.accepts,
+    dbFile.rejects,
+    dbFile.comment_indices,
+    false
+  );
+
+  setDocumentComments(document.id, dbFile.comments);
+
+  onRefresh(slateForm);
 }


### PR DESCRIPTION
Oops sorry mega PR but basically this just adds the pathways and database connections such that
- on upload, we register a file to the database
- add a button to the toolbar where you can basically write your state to the database. State includes all redactions and also comments
- add a button where you can pull state from the database (sync) and restore whatever state is there, comments and redactions

So it's the buttons, some state transforms to get back and forth between index and Slate forms for redactions/comments, and various backend/db code to write things to and from the db.

https://www.loom.com/share/ddd0c14e460d4010bdc7af3365cae811?sid=efccbaf3-21fb-4666-a394-3bb787d0b6f4